### PR TITLE
Working Push Notifications

### DIFF
--- a/example/api/stack.yaml
+++ b/example/api/stack.yaml
@@ -3,4 +3,4 @@ packages:
 - '../..'
 extra-deps:
 - pusher-http-haskell-1.1.0.1
-resolver: nightly-2016-09-22
+resolver: nightly-2017-04-14

--- a/example/auth/stack.yaml
+++ b/example/auth/stack.yaml
@@ -3,4 +3,4 @@ packages:
 - '../..'
 extra-deps:
 - pusher-http-haskell-1.1.0.1
-resolver: nightly-2016-09-22
+resolver: nightly-2017-04-14

--- a/example/push/Main.hs
+++ b/example/push/Main.hs
@@ -1,0 +1,52 @@
+module Main where
+
+import Control.Exception (displayException)
+import Data.Aeson ((.=))
+import Data.Monoid ((<>))
+
+import qualified Data.Aeson as A
+import qualified Data.ByteString.Lazy as BS
+import qualified Data.HashMap.Strict as H
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import qualified Data.Yaml as Y
+import qualified Network.Pusher as P
+import qualified Network.Pusher.Protocol as P
+
+main :: IO ()
+main = do
+  eitherCred <- Y.decodeFileEither "../credentials.yaml"
+  case eitherCred of
+    Left e -> print e
+    Right cred -> do
+      pusher <- P.getPusher cred
+      demoPushNotification pusher
+
+demoPushNotification :: P.Pusher -> IO ()
+demoPushNotification pusher = do
+  let Just interest = P.mkInterest "exampleinterest"
+      fcmObject :: A.Object
+      fcmObject =
+        H.fromList
+          [ ( "notification"
+            , A.Object $
+              H.fromList
+                [ ("title", A.String "Sup?")
+                , ("body", A.String "Hello Firebase.")
+                , ("icon", A.String "firebase-logo.png")
+                ])
+          ]
+      notification =
+        P.Notification
+        { P.notificationInterest = interest
+        , P.notificationWebhookURL = Nothing
+        , P.notificationWebhookLevel = Nothing
+        , P.notificationAPNSPayload = Nothing
+        , P.notificationGCMPayload = Nothing
+        , P.notificationFCMPayload = Just $ P.FCMPayload fcmObject
+        }
+  notifyResult <- P.notify pusher notification
+  T.putStrLn $
+    case notifyResult of
+      Left e -> "Notify failed: " <> (T.pack $ displayException e)
+      Right () -> "Notify success"

--- a/example/push/push-example.cabal
+++ b/example/push/push-example.cabal
@@ -1,0 +1,22 @@
+name:                 push-example
+version:              0.0.0.1
+cabal-version:        >=1.18
+build-type:           Simple
+license:              MIT
+stability:            experimental
+synopsis:             Example usage of pusher-http-haskell to send push notifications.
+executable push-example
+  default-language:   Haskell2010
+  default-extensions: OverloadedStrings
+  main-is:            Main.hs
+  build-depends:      base,
+                      pusher-http-haskell,
+                      text,
+                      aeson,
+                      bytestring,
+                      unordered-containers,
+                      yaml
+  ghc-options:        -Wall
+                      -Wcompat
+                      -Whi-shadowing
+                      -Wmissing-signatures

--- a/example/push/stack.yaml
+++ b/example/push/stack.yaml
@@ -1,0 +1,5 @@
+packages:
+- '.'
+- '../..'
+extra-deps:
+resolver: nightly-2017-04-14

--- a/pusher-http-haskell.cabal
+++ b/pusher-http-haskell.cabal
@@ -44,7 +44,7 @@ library
         time >=1.5 && <1.7,
         transformers >=0.4 && <0.6,
         unordered-containers ==0.2.*,
-        vector
+        vector ==0.12.*
     default-language: Haskell2010
     default-extensions: OverloadedStrings
     hs-source-dirs: src

--- a/pusher-http-haskell.cabal
+++ b/pusher-http-haskell.cabal
@@ -73,7 +73,9 @@ test-suite tests
         QuickCheck -any,
         text -any,
         transformers -any,
-        unordered-containers -any
+        unordered-containers -any,
+        vector -any,
+        scientific
     default-language: Haskell2010
     default-extensions: OverloadedStrings
     hs-source-dirs: test

--- a/pusher-http-haskell.cabal
+++ b/pusher-http-haskell.cabal
@@ -43,7 +43,8 @@ library
         text ==1.2.*,
         time >=1.5 && <1.7,
         transformers >=0.4 && <0.6,
-        unordered-containers ==0.2.*
+        unordered-containers ==0.2.*,
+        vector
     default-language: Haskell2010
     default-extensions: OverloadedStrings
     hs-source-dirs: src

--- a/pusher-http-haskell.cabal
+++ b/pusher-http-haskell.cabal
@@ -80,4 +80,5 @@ test-suite tests
     other-modules:
         Auth
         Protocol
+        Push
     ghc-options: -Wall

--- a/pusher-http-haskell.cabal
+++ b/pusher-http-haskell.cabal
@@ -44,7 +44,7 @@ library
         time >=1.5 && <1.7,
         transformers >=0.4 && <0.6,
         unordered-containers ==0.2.*,
-        vector ==0.12.*
+        vector >=0.10.0.0 && <0.13
     default-language: Haskell2010
     default-extensions: OverloadedStrings
     hs-source-dirs: src

--- a/src/Network/Pusher.hs
+++ b/src/Network/Pusher.hs
@@ -30,14 +30,42 @@ An example of how you would use these functions:
       , credentialsCluster   = Nothing
       }
   pusher <- getPusher credentials
-  result <-
-    trigger pusher [Channel Public "my-channel"] "my-event" "my-data" Nothing
-  case result of
-    Left e -> error e
-    Right resp -> print resp
-@
 
-There is a simple working example in the example/ directory.
+  triggerRes <-
+    trigger pusher [Channel Public "my-channel"] "my-event" "my-data" Nothing
+
+  case triggerRes of
+    Left e -> putStrLn $ displayException e
+    Right resp -> print resp
+
+  -- import qualified Data.HashMap.Strict as H
+  -- import qualified Data.Aeson          as A
+  let
+    -- A Firebase Cloud Messaging notification payload
+    fcmObject = H.fromList [("notification", A.Object $ H.fromList
+                                [("title", A.String "TITLE")
+                                ,("body" , A.String "BODY")
+                                ,("icon" , A.String "logo.png")
+                                ]
+                            )]
+    Just interest = mkInterest "INTEREST"
+
+    -- A Pusher notification
+    notification = Notification
+      { notificationInterest     = interest
+      , notificationWebhookURL   = Nothing
+      , notificationWebhookLevel = Nothing
+      , notificationAPNSPayload  = Nothing
+      , notificationGCMPayload   = Nothing
+      , notificationFCMPayload   = Just $ FCMPayload fcmObject
+      }
+
+  notifyRes <- notify pusher notification
+
+  @
+
+
+There are simple working examples in the example/ directory.
 
 See https://pusher.com/docs/rest_api for more detail on the HTTP requests.
 -}

--- a/src/Network/Pusher.hs
+++ b/src/Network/Pusher.hs
@@ -62,7 +62,7 @@ An example of how you would use these functions:
 
   notifyRes <- notify pusher notification
 
-  @
+@
 
 
 There are simple working examples in the example/ directory.

--- a/src/Network/Pusher/Data.hs
+++ b/src/Network/Pusher/Data.hs
@@ -233,6 +233,7 @@ type SocketID = T.Text
 -- interest names with prefixes such as private- or presence-
 newtype Interest =
   Interest T.Text
+  deriving (Eq,Show)
 
 mkInterest :: T.Text -> Maybe Interest
 mkInterest txt
@@ -264,6 +265,7 @@ type WebhookURL = T.Text
 data WebhookLevel
   = Info -- ^ Errors only
   | Debug -- ^ Everything
+  deriving (Eq,Show)
 
 instance A.FromJSON WebhookLevel where
   parseJSON v =
@@ -284,6 +286,7 @@ instance A.ToJSON WebhookLevel where
 -- TODO: Replace JSON object with a stronger encoding.
 data APNSPayload =
   APNSPayload A.Object
+  deriving (Eq,Show)
 
 instance A.FromJSON APNSPayload where
   parseJSON v =
@@ -298,6 +301,7 @@ instance A.ToJSON APNSPayload where
 -- TODO: Replace JSON object with a stronger encoding.
 data GCMPayload =
   GCMPayload A.Object
+  deriving (Eq,Show)
 
 instance A.FromJSON GCMPayload where
   parseJSON v =
@@ -312,6 +316,7 @@ instance A.ToJSON GCMPayload where
 -- TODO: Replace JSON object with a stronger encoding.
 data FCMPayload =
   FCMPayload A.Object
+  deriving (Eq,Show)
 
 instance A.FromJSON FCMPayload where
   parseJSON v =
@@ -330,6 +335,7 @@ data Notification = Notification
   , notificationGCMPayload :: Maybe GCMPayload
   , notificationFCMPayload :: Maybe FCMPayload
   }
+  deriving (Eq,Show)
 
 instance A.FromJSON Notification where
   parseJSON (A.Object v) =

--- a/src/Network/Pusher/Data.hs
+++ b/src/Network/Pusher/Data.hs
@@ -236,7 +236,7 @@ newtype Interest =
 
 mkInterest :: T.Text -> Maybe Interest
 mkInterest txt
-  | T.length txt <= 164 &&
+  |  0 < T.length txt && T.length txt <= 164 &&
       T.all (\c -> isAlphaNum c || HS.member c permitted) txt =
     Just . Interest $ txt
   | otherwise = Nothing

--- a/src/Network/Pusher/Data.hs
+++ b/src/Network/Pusher/Data.hs
@@ -39,24 +39,37 @@ module Network.Pusher.Data
   , Event
   , EventData
   , SocketID
+  -- * Notifications
+  , Notification(..)
+  , Interest
+  , mkInterest
+  , WebhookURL
+  , WebhookLevel(..)
+  , APNSPayload(..)
+  , GCMPayload(..)
+  , FCMPayload(..)
   ) where
 
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Data.Aeson ((.:), (.:?))
+import Data.Aeson ((.:), (.:?), (.=))
 import qualified Data.Aeson as A
 import qualified Data.ByteString as B
+import Data.Char
 import Data.Foldable (asum)
+import qualified Data.HashSet as HS
 import Data.Hashable (Hashable)
 import Data.Maybe (fromMaybe)
 import Data.Monoid ((<>))
 import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
+import qualified Data.Vector as V
 import GHC.Generics (Generic)
 import Network.HTTP.Client
        (Manager, defaultManagerSettings, newManager)
 
 import Network.Pusher.Internal.Util
-       (failExpectObj, failExpectStr, show')
+       (failExpectObj, failExpectSingletonArray, failExpectArray,
+        failExpectStr, show')
 
 type AppID = Integer
 
@@ -68,6 +81,8 @@ type AppSecret = B.ByteString
 data Pusher = Pusher
   { pusherHost :: T.Text
   , pusherPath :: T.Text
+  , pusherNotifyHost :: T.Text
+  , pusherNotifyPath :: T.Text
   , pusherCredentials :: Credentials
   , pusherConnectionManager :: Manager
   }
@@ -118,25 +133,35 @@ getPusher
   => Credentials -> m Pusher
 getPusher cred = do
   connManager <- getConnManager
-  return $ getPusherWithConnManager connManager Nothing cred
+  return $ getPusherWithConnManager connManager Nothing Nothing cred
 
 -- |Get a Pusher instance that uses a specific API endpoint.
 getPusherWithHost
   :: MonadIO m
-  => T.Text -> Credentials -> m Pusher
-getPusherWithHost apiHost cred = do
+  => T.Text -> T.Text -> Credentials -> m Pusher
+getPusherWithHost apiHost notifyHost cred = do
   connManager <- getConnManager
-  return $ getPusherWithConnManager connManager (Just apiHost) cred
+  return $
+    getPusherWithConnManager connManager (Just apiHost) (Just notifyHost) cred
 
 -- |Get a Pusher instance with a given connection manager. This can be useful
 -- if you want to share a connection with your application code.
-getPusherWithConnManager :: Manager -> Maybe T.Text -> Credentials -> Pusher
-getPusherWithConnManager connManager apiHost cred =
+getPusherWithConnManager :: Manager
+                         -> Maybe T.Text
+                         -> Maybe T.Text
+                         -> Credentials
+                         -> Pusher
+getPusherWithConnManager connManager apiHost notifyAPIHost cred =
   let path = "/apps/" <> show' (credentialsAppID cred) <> "/"
       mCluster = credentialsCluster cred
+      notifyPath =
+        "/server_api/v1/apps/" <> show' (credentialsAppID cred) <> "/"
   in Pusher
      { pusherHost = fromMaybe (mkHost mCluster) apiHost
      , pusherPath = path
+     , pusherNotifyHost =
+         fromMaybe "http://nativepush-cluster1.pusher.com" notifyAPIHost
+     , pusherNotifyPath = notifyPath
      , pusherCredentials = cred
      , pusherConnectionManager = connManager
      }
@@ -201,3 +226,136 @@ type Event = T.Text
 type EventData = T.Text
 
 type SocketID = T.Text
+
+-- | Up to 164 characters where each character is ASCII upper or lower case, a
+-- number or one of _=@,.;
+-- Note: hyphen - is NOT valid as it is reserved for the possibility of marking
+-- interest names with prefixes such as private- or presence-
+newtype Interest =
+  Interest T.Text
+
+mkInterest :: T.Text -> Maybe Interest
+mkInterest txt
+  | T.length txt <= 164 &&
+      T.all (\c -> isAlphaNum c || HS.member c permitted) txt =
+    Just . Interest $ txt
+  | otherwise = Nothing
+  where
+    permitted = HS.fromList "_=@,.;"
+
+instance A.FromJSON Interest where
+  parseJSON v =
+    case v of
+      A.String s ->
+        case mkInterest s of
+          Nothing ->
+            fail $
+            "An Interest contains invalid characters or is too long: " ++ show s
+          Just istr -> pure istr
+      _ -> failExpectStr v
+
+instance A.ToJSON Interest where
+  toJSON (Interest txt) = A.String txt
+
+-- | URL to which pusher will send information about sent push notifications
+type WebhookURL = T.Text
+
+-- | Level of detail sent to WebhookURL. Defaults to Info
+data WebhookLevel
+  = Info -- ^ Errors only
+  | Debug -- ^ Everything
+
+instance A.FromJSON WebhookLevel where
+  parseJSON v =
+    case v of
+      A.String s
+        | s == "INFO" -> pure Info
+        | s == "DEBUG" -> pure Debug
+      _ -> failExpectStr v
+
+instance A.ToJSON WebhookLevel where
+  toJSON w =
+    A.String $
+    case w of
+      Info -> "INFO"
+      Debug -> "DEBUG"
+
+-- | Apple push notification service payload
+-- TODO: Replace JSON object with a stronger encoding.
+data APNSPayload =
+  APNSPayload A.Object
+
+instance A.FromJSON APNSPayload where
+  parseJSON v =
+    case v of
+      A.Object o -> pure . APNSPayload $ o
+      _ -> failExpectObj v
+
+instance A.ToJSON APNSPayload where
+  toJSON (APNSPayload o) = A.Object o
+
+-- | Google Cloud Messaging payload
+-- TODO: Replace JSON object with a stronger encoding.
+data GCMPayload =
+  GCMPayload A.Object
+
+instance A.FromJSON GCMPayload where
+  parseJSON v =
+    case v of
+      A.Object o -> pure . GCMPayload $ o
+      _ -> failExpectObj v
+
+instance A.ToJSON GCMPayload where
+  toJSON (GCMPayload o) = A.Object o
+
+-- | Firebase Cloud Messaging payload
+-- TODO: Replace JSON object with a stronger encoding.
+data FCMPayload =
+  FCMPayload A.Object
+
+instance A.FromJSON FCMPayload where
+  parseJSON v =
+    case v of
+      A.Object o -> pure . FCMPayload $ o
+      _ -> failExpectObj v
+
+instance A.ToJSON FCMPayload where
+  toJSON (FCMPayload o) = A.Object o
+
+data Notification = Notification
+  { notificationInterest :: Interest
+  , notificationWebhookURL :: Maybe WebhookURL
+  , notificationWebhookLevel :: Maybe WebhookLevel
+  , notificationAPNSPayload :: Maybe APNSPayload
+  , notificationGCMPayload :: Maybe GCMPayload
+  , notificationFCMPayload :: Maybe FCMPayload
+  }
+
+instance A.FromJSON Notification where
+  parseJSON (A.Object v) =
+    Notification <$>
+    (do interests <- v A..: "interests"
+        case interests of
+          A.Array arr
+            | V.length arr == 1 -> A.parseJSON $ V.head arr
+            | otherwise -> failExpectSingletonArray interests
+          v' -> failExpectArray v') <*>
+    v .:? "webhook_url" <*>
+    v .:? "webhook_level" <*>
+    v .:? "apns" <*>
+    v .:? "gcm" <*>
+    v .:? "fcm"
+  parseJSON v = failExpectObj v
+
+instance A.ToJSON Notification where
+  toJSON (Notification interests mWebhookURL mWebhookLevel mAPNS mGCMP mFCMP) =
+    let requiredFields = ["interests" .= [interests]]
+        consOptionals =
+          consJust "webhook_level" mWebhookLevel .
+          consJust "webhook_url" mWebhookURL .
+          consJust "apns" mAPNS . consJust "gcm" mGCMP . consJust "fcm" mFCMP
+        fields = consOptionals requiredFields
+    in A.object fields
+      -- Cons a attribute value pair if Just
+    where
+      consJust attr = maybe id ((:) . (attr .=))

--- a/src/Network/Pusher/Internal/Auth.hs
+++ b/src/Network/Pusher/Internal/Auth.hs
@@ -23,6 +23,7 @@ module Network.Pusher.Internal.Auth
   ) where
 
 import qualified Data.Aeson as A
+import Data.Char (toLower)
 import Data.Monoid ((<>))
 import Data.Text.Encoding (encodeUtf8)
 import GHC.Exts (sortWith)
@@ -34,8 +35,9 @@ import qualified Data.Aeson.Encode as A
 import qualified Crypto.Hash.MD5 as MD5
 import qualified Crypto.Hash.SHA256 as SHA256
 import qualified Crypto.MAC.HMAC as HMAC
-import qualified Data.ByteString as B
+import qualified Data.ByteString as B hiding (map)
 import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Char8 as B
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TL
@@ -57,26 +59,34 @@ makeQS
   -> B.ByteString
   -> Int -- ^Current UNIX timestamp
   -> RequestQueryString
-makeQS appKey appSecret method path params body ts =
-  let allParams
-    -- Generate all required parameters and add them to the list of existing
-    -- ones
-       =
-        sortWith fst $
-        params ++
+makeQS appKey appSecret method fullPath params body ts
+    -- Generate all required parameters and add them to the list of existing ones
+    -- Parameters are:
+    -- - In alphabetical order
+    -- - Keys are lower case
+ =
+  let allParams =
+        alphabeticalOrder . lowercaseKeys . (params ++) $
         [ ("auth_key", appKey)
         , ("auth_timestamp", show' ts)
         , ("auth_version", "1.0")
         , ("body_md5", B16.encode (MD5.hash body))
         ]
     -- Generate the auth signature from the list of parameters
+    -- - Method name is upper case
       authSig =
         authSignature appSecret $
         B.intercalate
           "\n"
-          [encodeUtf8 method, encodeUtf8 path, formQueryString allParams]
+          [ encodeUtf8 . T.toUpper $ method
+          , encodeUtf8 fullPath
+          , formQueryString allParams
+          ]
     -- Add the auth string to the list
   in ("auth_signature", authSig) : allParams
+  where
+    alphabeticalOrder = sortWith fst
+    lowercaseKeys = map (\(k, v) -> (B.map toLower k, v))
 
 -- |Render key-value tuple mapping of query string parameters into a string.
 formQueryString :: RequestQueryString -> B.ByteString

--- a/src/Network/Pusher/Internal/Auth.hs
+++ b/src/Network/Pusher/Internal/Auth.hs
@@ -37,7 +37,7 @@ import qualified Crypto.Hash.SHA256 as SHA256
 import qualified Crypto.MAC.HMAC as HMAC
 import qualified Data.ByteString as B hiding (map)
 import qualified Data.ByteString.Base16 as B16
-import qualified Data.ByteString.Char8 as B
+import qualified Data.ByteString.Char8 as BC
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TL
@@ -86,7 +86,7 @@ makeQS appKey appSecret method fullPath params body ts
   in ("auth_signature", authSig) : allParams
   where
     alphabeticalOrder = sortWith fst
-    lowercaseKeys = map (\(k, v) -> (B.map toLower k, v))
+    lowercaseKeys = map (\(k, v) -> (BC.map toLower k, v))
 
 -- |Render key-value tuple mapping of query string parameters into a string.
 formQueryString :: RequestQueryString -> B.ByteString

--- a/src/Network/Pusher/Internal/HTTP.hs
+++ b/src/Network/Pusher/Internal/HTTP.hs
@@ -44,7 +44,7 @@ data RequestParams = RequestParams
   -- ^The API endpoint, for example http://api.pusherapp.com/apps/123/events
   , requestQueryString :: RequestQueryString
   -- ^List of query string parameters as key-value tuples
-  }
+  } deriving (Show)
 
 type RequestQueryString = [(B.ByteString, B.ByteString)]
 
@@ -59,7 +59,7 @@ get
   -> ExceptT PusherError IO a -- ^The body of the response
 get connManager (RequestParams ep qs) = do
   req <- ExceptT $ return $ mkRequest ep qs
-  resp <- doReqest connManager req
+  resp <- doRequest connManager req
   either
     (throwE . PusherInvalidResponseError . T.pack)
     return
@@ -71,7 +71,7 @@ post
   => HTTP.Client.Manager -> RequestParams -> a -> ExceptT PusherError IO ()
 post connManager (RequestParams ep qs) body = do
   req <- ExceptT $ return $ mkPost (A.encode body) <$> mkRequest ep qs
-  _ <- doReqest connManager req
+  _ <- doRequest connManager req
   return ()
 
 mkRequest :: T.Text
@@ -96,11 +96,11 @@ mkPost body req =
   , HTTP.Client.requestBody = HTTP.Client.RequestBodyLBS body
   }
 
-doReqest
+doRequest
   :: HTTP.Client.Manager
   -> HTTP.Client.Request
   -> ExceptT PusherError IO BL.ByteString
-doReqest connManager req = do
+doRequest connManager req = do
   response <- liftIO $ HTTP.Client.httpLbs req connManager
   let status = HTTP.Client.responseStatus response
   if statusCode status == 200

--- a/src/Network/Pusher/Internal/HTTP.hs
+++ b/src/Network/Pusher/Internal/HTTP.hs
@@ -103,8 +103,11 @@ doRequest
 doRequest connManager req = do
   response <- liftIO $ HTTP.Client.httpLbs req connManager
   let status = HTTP.Client.responseStatus response
-  if statusCode status == 200
-    then return $ HTTP.Client.responseBody response
+      code = statusCode status
+      bodyBs :: BL.ByteString
+      bodyBs = HTTP.Client.responseBody response
+  if code `elem` [200, 202]
+    then return bodyBs
     else let decoded = decodeUtf8' $ statusMessage status
          in throwE $
             either

--- a/src/Network/Pusher/Internal/Util.hs
+++ b/src/Network/Pusher/Internal/Util.hs
@@ -8,7 +8,9 @@ Stability   : experimental
 -}
 module Network.Pusher.Internal.Util
   ( failExpectObj
+  , failExpectArray
   , failExpectStr
+  , failExpectSingletonArray
   , getTime
   , show'
   ) where
@@ -26,6 +28,18 @@ getTime = round <$> getPOSIXTime
 -- when an object was expected, but it was a different type of data.
 failExpectObj :: A.Value -> A.Parser a
 failExpectObj = fail . ("Expected JSON object, got " ++) . show
+
+-- |When decoding Aeson values, this can be used to return a failing parser
+-- when an array was expected, but it was a different type of data.
+failExpectArray :: A.Value -> A.Parser a
+failExpectArray = fail . ("Expected JSON array, got " ++) . show
+
+-- |When decoding Aeson values, this can be used to return a failing parser
+-- when an array of length exactly one was expected but it was a different type
+-- of data.
+failExpectSingletonArray :: A.Value -> A.Parser a
+failExpectSingletonArray =
+  fail . ("Expected JSON array with exactly one object, got" ++) . show
 
 -- |When decoding Aeson values, this can be used to return a failing parser
 -- when an string was expected, but it was a different type of data.

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -4,6 +4,7 @@ import Test.Hspec (hspec)
 
 import qualified Auth
 import qualified Protocol
+import qualified Push
 
 main :: IO ()
-main = hspec $ Auth.test >> Protocol.test
+main = hspec $ Auth.test >> Protocol.test >> Push.test

--- a/test/Push.hs
+++ b/test/Push.hs
@@ -22,37 +22,37 @@ import Network.Pusher
 
 test :: Spec
 test = do
-  describe "Interest names are validated" $ do
-    it "Correct Interest names are accepted" $
+  describe "Interest names" $ do
+    it "are accepted when using valid characters" $
       property $ do
         txt <- arbitraryInterestText
         return $
           case mkInterest txt of
             Nothing -> False
             Just _ -> True
-    it "Invalid Interest names are rejected" $
+    it "are rejected when using invalid characters" $
       property $ do
         txt <- arbitraryInvalidInterestText
         return $
           case mkInterest txt of
             Nothing -> True
             Just _ -> False
-  describe "Notifications parse" $ do
-    it "A specific FCM Notification JSON parses correctly" $
+  describe "Notification JSON parser" $ do
+    it "correctly parses a specific FCM Notification." $
       property $
       let (inputBS, expected) = validFCMDecoding
       in A.decode inputBS == Just expected
     it "Random Notifications JSON parses correctly" $
       property $ \(NotificationDecoding (bs, notification)) ->
         A.decode bs == Just notification
-  describe "Notifications encode" $ do
-    it "A specific FCM Notification encodes to JSON correctly" $
+  describe "Notification JSON encoder" $ do
+    it "encodes a specific FCM Notification correctly" $
       property $
       let (bs, notification) = validFCMDecoding
       in (A.encode notification) ==
          (A.encode . fromJust . (A.decode :: ByteString -> Maybe Notification) $
           bs)
-    it "Random Notifications encode to JSON correctly" $
+    it "encodes random Notifications correctly" $
       -- NOTE: We put the expected string through a round trip to normalise trivial
       -- differences such as ordering and spacing in the JSON Aeson generates
       property $ \(NotificationDecoding (bs, notification)) ->

--- a/test/Push.hs
+++ b/test/Push.hs
@@ -1,14 +1,19 @@
+{-# LANGUAGE OverloadedStrings #-}
+
 module Push where
 
 import qualified Data.Aeson as A
 import Data.Aeson ((.=))
+import Data.ByteString.Lazy (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as B
 import qualified Data.HashMap.Strict as HM
 import Data.Maybe (fromJust)
+import Data.Monoid ((<>))
 import qualified Data.Text as T
 
-import Test.Hspec (Spec, describe, it, shouldBe)
-import Test.QuickCheck (elements, property, Gen, vectorOf, oneof)
+import Test.Hspec (Spec, describe, it)
+import Test.QuickCheck
+       (elements, property, Gen, vectorOf, oneof, Arbitrary(..))
 
 import Network.Pusher
 
@@ -29,11 +34,28 @@ test = do
           case mkInterest txt of
             Nothing -> True
             Just _ -> False
-  describe "Notifications parse" $
-    it "Notification JSON parses correctly" $
-    property $
-    let (inputBS, expected) = validFCMDecoding
-    in A.decode inputBS == Just expected
+  describe "Notifications parse" $ do
+    it "A specific FCM Notification JSON parses correctly" $
+      property $
+      let (inputBS, expected) = validFCMDecoding
+      in A.decode inputBS == Just expected
+    it "Random Notifications JSON parses correctly" $
+      property $ \(NotificationDecoding (bs, notification)) ->
+        A.decode bs == Just notification
+  describe "Notifications encode" $ do
+    it "A specific FCM Notification encodes to JSON correctly" $
+      property $
+      let (bs, notification) = validFCMDecoding
+      in (A.encode notification) ==
+         (A.encode . fromJust . (A.decode :: ByteString -> Maybe Notification) $
+          bs)
+    it "Random Notifications encode to JSON correctly" $
+      -- NOTE: We put the expected string through a round trip to normalise trivial
+      -- differences such as ordering and spacing in the JSON Aeson generates
+      property $ \(NotificationDecoding (bs, notification)) ->
+        (A.encode notification) ==
+        (A.encode . fromJust . (A.decode :: ByteString -> Maybe Notification) $
+         bs)
 
 -- A single example of a FCM notification which we expect to aeson decode to
 -- the paired Notification value.
@@ -70,6 +92,80 @@ validFCMDecoding =
               ]
         }
   in (bs, notification)
+
+-- | A ByteString will decode to some value 'a'.
+type Decoding a = (B.ByteString, a)
+
+newtype NotificationDecoding =
+  NotificationDecoding (Decoding Notification)
+  deriving (Show)
+
+newtype APNSDecoding =
+  APNSDecoding (Decoding (Maybe APNSPayload))
+
+newtype FCMDecoding =
+  FCMDecoding (Decoding (Maybe FCMPayload))
+
+newtype GCMDecoding =
+  GCMDecoding (Decoding (Maybe GCMPayload))
+
+instance Arbitrary APNSDecoding where
+  arbitrary = return $ APNSDecoding ("", Nothing)
+
+instance Arbitrary GCMDecoding where
+  arbitrary = return $ GCMDecoding ("", Nothing)
+
+instance Arbitrary FCMDecoding where
+  arbitrary = return $ FCMDecoding ("", Nothing)
+
+instance Arbitrary NotificationDecoding where
+  arbitrary = do
+    interestName <- arbitraryInterestText
+    APNSDecoding (apnsBS, mAPNS) <- arbitrary
+    GCMDecoding (gcmBS, mGCM) <- arbitrary
+    FCMDecoding (fcmBS, mFCM) <- arbitrary
+    let notification =
+          Notification
+          { notificationInterest = fromJust . mkInterest $ interestName
+          , notificationWebhookURL = Nothing
+          , notificationWebhookLevel = Nothing
+          , notificationAPNSPayload = mAPNS
+          , notificationGCMPayload = mGCM
+          , notificationFCMPayload = mFCM
+          }
+        -- Key value pairs that are required
+        requiredFields :: [(ByteString, ByteString)]
+        requiredFields =
+          [("interests", "[\"" <> (B.pack . T.unpack $ interestName) <> "\"]")]
+        -- A function which takes an initial key value pair list and adds Just pairs and skips Nothing values.
+        -- Aeson would by default encode this as "value":null which we dont want.
+        consOptionals :: [(ByteString, ByteString)]
+                      -> [(ByteString, ByteString)]
+        consOptionals =
+          consJust "apns" (nullToMaybe apnsBS) .
+          consJust "fcm" (nullToMaybe fcmBS) .
+          consJust "gcm" (nullToMaybe gcmBS)
+        fields :: [(ByteString, ByteString)]
+        fields = consOptionals requiredFields
+        bs :: B.ByteString
+        bs =
+          (\acc -> "{" <> acc <> "}") .
+          B.intercalate "," . map (\(k, v) -> "\"" <> k <> "\": " <> v) $
+          fields
+    return $ NotificationDecoding (bs, notification)
+      -- Cons an attribute value pair if Just
+    where
+      consJust
+        :: ByteString
+        -> Maybe ByteString
+        -> [(ByteString, ByteString)]
+        -> [(ByteString, ByteString)]
+      consJust attr = maybe id (\val rest -> (attr, val) : rest)
+      -- Empty ByteStrings become null
+      nullToMaybe :: B.ByteString -> Maybe B.ByteString
+      nullToMaybe bs
+        | B.null bs = Nothing
+        | otherwise = Just bs
 
 -- Valid interest names
 arbitraryInterestText :: Gen T.Text

--- a/test/Push.hs
+++ b/test/Push.hs
@@ -1,0 +1,59 @@
+module Push where
+
+import qualified Data.Text as T
+
+import Test.Hspec (Spec, describe, it)
+import Test.QuickCheck (elements, property, Gen, vectorOf, oneof)
+
+import Network.Pusher
+
+test :: Spec
+test = do
+  describe "Interest names are validated" $ do
+    it "Correct Interest names are accepted" $
+      property $ do
+        txt <- arbitraryInterestText
+        return $
+          case mkInterest txt of
+            Nothing -> False
+            Just _ -> True
+    it "Invalid Interest names are rejected" $
+      property $ do
+        txt <- arbitraryInvalidInterestText
+        return $
+          case mkInterest txt of
+            Nothing -> True
+            Just _ -> False
+
+-- Valid interest names
+arbitraryInterestText :: Gen T.Text
+arbitraryInterestText = do
+  n <- elements [1 .. 164]
+  str <-
+    vectorOf n $
+    elements $
+    concat
+      [['a' .. 'z'], ['A' .. 'Z'], ['0' .. '1'], ['_', '=', '@', ',', '.', ';']]
+  return . T.pack $ str
+
+-- Invalid interest names
+arbitraryInvalidInterestText :: Gen T.Text
+arbitraryInvalidInterestText =
+  T.pack <$>
+  oneof
+    [tooLargeInterestText, tooSmallInterestText, invalidCharactersInterestText]
+  where
+    tooLargeInterestText = do
+      n <- elements [165 .. 265]
+      vectorOf n $
+        elements $
+        concat
+          [ ['a' .. 'z']
+          , ['A' .. 'Z']
+          , ['0' .. '1']
+          , ['_', '=', '@', ',', '.', ';']
+          ]
+    tooSmallInterestText = return ""
+    invalidCharactersInterestText = do
+      n <- elements [1 .. 165]
+      vectorOf n $ elements "!\"£$%^&*()+}{~:?><¬` `}\""

--- a/test/Push.hs
+++ b/test/Push.hs
@@ -65,16 +65,15 @@ test = do
 validFCMDecoding :: (B.ByteString, Notification)
 validFCMDecoding =
   let bs =
-        B.unlines
-          [ "{"
-          , "\"interests\": [\"interestOne\"],"
-          , "\"fcm\": { \"notification\": {"
-          , "              \"body\": \"bodyText\","
-          , "              \"title\": \"titleText\""
-          , "                             }"
-          , "         }"
-          , "}"
-          ]
+        "{\
+          \ \"interests\": [\"interestOne\"]\
+          \ ,\"fcm\": {\
+          \     \"notification\":\
+          \        {\"title\":\"titleText\"\
+          \        ,\"body\":\"bodyText\"\
+          \        }\
+          \  }\
+          \}"
       notification =
         Notification
         { notificationInterest = fromJust . mkInterest $ "interestOne"
@@ -126,22 +125,22 @@ instance Arbitrary APNSDecoding where
     let apns = APNSPayload payload
         bs :: ByteString
         bs =
-          mconcat
-            [ "{"
-            , "\"aps\":"
-            , "{"
-            , "              \"alert\":{\"title\":\""
-            , (B.pack . T.unpack $ titleText)
-            , "\""
-            , "                        ,\"body\":\""
-            , (B.pack . T.unpack $ bodyText)
-            , "\""
-            , "                        }"
-            , "            }"
-            , ",\"data\":"
-            , (A.encode dataJSON)
-            , "}"
-            ]
+          "{\
+          \  \"aps\":\
+          \   {\
+          \     \"alert\":\
+          \       {\"title\":\"" <>
+          (B.pack . T.unpack $ titleText) <>
+          "\"\
+          \       ,\"body\":\"" <>
+          (B.pack . T.unpack $ bodyText) <>
+          "\"\
+          \       }\
+          \   }\
+          \   ,\"data\":" <>
+          (A.encode dataJSON) <>
+          "\
+          \}"
     return $ APNSDecoding (bs, Just apns)
 
 instance Arbitrary GCMDecoding where
@@ -157,20 +156,19 @@ instance Arbitrary GCMDecoding where
         gcm = GCMPayload payload
         bs :: ByteString
         bs =
-          mconcat
-            [ "{"
-            , "\"notification\":"
-            , "{\"title\":\""
-            , (B.pack . T.unpack $ titleText)
-            , "\""
-            , "                     ,\"body\":\""
-            , (B.pack . T.unpack $ bodyText)
-            , "\""
-            , "                     }"
-            , ",\"data\":"
-            , (A.encode dataJSON)
-            , "}"
-            ]
+          "{\
+          \  \"notification\":\
+          \    {\"title\":\"" <>
+          (B.pack . T.unpack $ titleText) <>
+          "\"\
+          \    ,\"body\":\"" <>
+          (B.pack . T.unpack $ bodyText) <>
+          "\"\
+          \    }\
+          \    ,\"data\":" <>
+          (A.encode dataJSON) <>
+          "\
+          \}"
     return $ GCMDecoding (bs, Just gcm)
 
 instance Arbitrary FCMDecoding where
@@ -186,20 +184,19 @@ instance Arbitrary FCMDecoding where
         gcm = FCMPayload payload
         bs :: ByteString
         bs =
-          mconcat
-            [ "{"
-            , "\"notification\":"
-            , "{\"title\":\""
-            , (B.pack . T.unpack $ titleText)
-            , "\""
-            , "                     ,\"body\":\""
-            , (B.pack . T.unpack $ bodyText)
-            , "\""
-            , "                     }"
-            , ",\"data\":"
-            , (A.encode dataJSON)
-            , "}"
-            ]
+          "{\
+          \  \"notification\":\
+          \    {\"title\":\"" <>
+          (B.pack . T.unpack $ titleText) <>
+          "\"\
+          \    ,\"body\":\"" <>
+          (B.pack . T.unpack $ bodyText) <>
+          "\"\
+          \    }\
+          \    ,\"data\":" <>
+          (A.encode dataJSON) <>
+          "\
+          \}"
     return $ FCMDecoding (bs, Just gcm)
 
 instance Arbitrary NotificationDecoding where

--- a/test/Push.hs
+++ b/test/Push.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE FlexibleInstances, OverloadedStrings,
-  ScopedTypeVariables #-}
-
 module Push where
 
 import Data.Aeson ((.=))


### PR DESCRIPTION
This is a pull request to add support for Push Notifications.

Why haven't I based this upon the existing [push-notifications](/pusher-community/pusher-http-haskell/tree/push-notifications) branch?
Well, I wrote 2/3rds of the support for Push Notifications while exploring the Pusher API, as I noticed it was missing and wanted to use it myself. It was only then that I noticed that work had already begun on [push-notifications](/pusher-community/pusher-http-haskell/tree/push-notifications) however it seemed to be unfinished and abandoned before completion. Therefore it seemed easier to just finish my current effort than attempt to merge.
I'd be happy to make amendments if desired.

2b5854da748badd3e5dd841b44387738aba2f478 contains the bulk of the work, adding Push Notifications. The design currently takes APNS,GCM,FCM payloads as JSON objects rather than defining a stricter type.
I'm of the opinion that it might be best to keep this interface (/for now) and either:
  - Allow the user to import a separate library for forming the JSON in a safer manner
  - Re-export such a library perhaps with a convenience function.
That way this library isn't concerned with implementing and maintaining the entire Google and Apple formats.
On the other hand, I noticed that some work has gone towards encoding APNS and GCM payloads in [push-notifications](/pusher-community/pusher-http-haskell/tree/push-notifications). If desired, merging these files should be simple.